### PR TITLE
fix(workflows): add workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,11 @@ on: push
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   lint-build-verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow permissions to follow the principle of least privilege. The workflow now explicitly requests only the permissions it needs to run.

Security improvements:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R6-R10): Added explicit `permissions` for `contents: read` and `checks: write` to limit the workflow's access to only what is required.